### PR TITLE
Update execute to not automatically add http://

### DIFF
--- a/api.js
+++ b/api.js
@@ -60,7 +60,15 @@ class api {
     const list = this.getList(name)
 
     if (list) {
-      list.sites = list.sites.concat(items)
+      list.sites = list.sites.concat(items.map((site) => {
+        // replace https:// with http://
+        if (site.indexOf('https://') === 0) {
+          return `http://${site.slice('https://'.length)}`
+        } else if (site.indexOf('http://') === 0){
+          return site
+        }
+        return `http://${site}`
+      }));
     } else {
       throw 'List not found.'
     }

--- a/modules/execute.js
+++ b/modules/execute.js
@@ -23,13 +23,9 @@ function executeList (api, list) {
     linux: 'xdg-open'
   }
 
-  const sites = list.sites.map( (site) => {
-    return `http://${site}`
-  })
-
-  if (sites.length) {
+  if (list.sites.length) {
     console.log(chalk.yellow('\launching...'))
-    exec(`${openCommands[process.platform]} ${sites.join(' ')}`)
+    exec(`${openCommands[process.platform]} ${list.sites.join(' ')}`)
     console.log(chalk.green('Done.'))
   } else {
     console.log(chalk.green(`No sites to run in `) + chalk.cyan(list.name))


### PR DESCRIPTION
If the user copy and pastes a URL, then concatenating http:// might lead to some URL like `http://https://google.com` which would error. 
